### PR TITLE
Added necessary files for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+################ MST MRD TRAVIS CI ################
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=drone_control/
+    
+install:
+    - pip install -U platformio
+
+script:
+    - ./prep.sh
+    - platformio ci --board=megaatmega2560

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ install:
     - pip install -U platformio
 
 script:
+    - chmod +x prep.sh
     - ./prep.sh
     - platformio ci --board=megaatmega2560

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Arduino [![Build Status](https://travis-ci.org/markrjr/Arduino.svg?branch=master)](https://travis-ci.org/markrjr/Arduino)
+Main code for Spring 2016's drone.

--- a/prep.sh
+++ b/prep.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+########### MST PREP SCRIPT FOR TRAVIS CI ###########
+
+cd "drone_control"
+
+echo -e "#include <Arduino.h>\n$(cat *.ino)" > *.ino
+
+for file in *.ino
+do
+ mv "$file" "${file%.ino}.cpp"
+done


### PR DESCRIPTION
The travis.yml file defines the necessary procedures in order to
compile this build. The prep bash script renames all files in the
drone_control directory and adds `#include <Arduino.h>.` This is a
necessary workaround for compiling with PlatformIO and is only temporary for the build.
